### PR TITLE
Removing state pollution in `geom.eps`

### DIFF
--- a/test_geom.py
+++ b/test_geom.py
@@ -12,6 +12,7 @@ def test_epsilon():
         geom.set_tolerance(0)
     with pytest.raises(ValueError):
         geom.set_tolerance(-1)
+    geom.set_tolerance(10 ** -6)
 
 def test_is_numeric():
     assert(geom.is_numeric(3))


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_epsilon` by removing state pollution in `geom.eps` by calling method `geom.set_tolerance`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test_geom.py::test_epsilon`:

```
    def test_epsilon():
>       assert(abs(geom.eps - 0.0001) < 0.0001)
E       assert 0.0099 < 0.0001
E        +  where 0.0099 = abs((0.01 - 0.0001))
E        +    where 0.01 = geom.eps
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
